### PR TITLE
Bugfix/locals_groups-return-object

### DIFF
--- a/src/main/java/com/pedro/sphynx/application/controller/LocalController.java
+++ b/src/main/java/com/pedro/sphynx/application/controller/LocalController.java
@@ -1,12 +1,11 @@
 package com.pedro.sphynx.application.controller;
 
-import com.pedro.sphynx.application.dtos.local.LocalDataComplete;
 import com.pedro.sphynx.application.dtos.local.LocalDataEditInput;
 import com.pedro.sphynx.application.dtos.local.LocalDataInput;
+import com.pedro.sphynx.application.dtos.localGroup.LocalGroupDataComplete;
 import com.pedro.sphynx.application.dtos.message.MessageDTO;
 import com.pedro.sphynx.domain.LocalService;
 import com.pedro.sphynx.domain.MessageService;
-import com.pedro.sphynx.infrastructure.repository.LocalGroupRepository;
 import com.pedro.sphynx.infrastructure.repository.LocalRepository;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,9 +21,6 @@ public class LocalController implements ControllerIN<LocalDataInput, LocalDataEd
 
     @Autowired
     private LocalRepository repository;
-
-    @Autowired
-    private LocalGroupRepository localGroupRepository;
 
     @Autowired
     private LocalService service;
@@ -54,8 +50,8 @@ public class LocalController implements ControllerIN<LocalDataInput, LocalDataEd
 
     @Override
     @GetMapping
-    public ResponseEntity<List<LocalDataComplete>> get(){
-        List<LocalDataComplete> localsList = service.getAllLocalsWithGroups();
+    public ResponseEntity<List<LocalGroupDataComplete>> get(){
+        List<LocalGroupDataComplete> localsList = service.getAllLocalsWithGroups();
         return ResponseEntity.ok(localsList);
     }
 

--- a/src/main/java/com/pedro/sphynx/application/dtos/local/LocalDataComplete.java
+++ b/src/main/java/com/pedro/sphynx/application/dtos/local/LocalDataComplete.java
@@ -6,8 +6,8 @@ import com.pedro.sphynx.infrastructure.entities.Local;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record LocalDataComplete(Long id, String name, String mac, LocalDateTime dtcreate, LocalDateTime dtupdate, List<Group> groups) {
+public record LocalDataComplete(Long id, String name, String mac, LocalDateTime dtcreate, LocalDateTime dtupdate) {
     public LocalDataComplete(Local data){
-        this(data.getId(), data.getName(), data.getMac(), data.getDtcreate(), data.getDtupdate(), data.getGroups());
+        this(data.getId(), data.getName(), data.getMac(), data.getDtcreate(), data.getDtupdate());
     }
 }

--- a/src/main/java/com/pedro/sphynx/application/dtos/localGroup/LocalGroupDataComplete.java
+++ b/src/main/java/com/pedro/sphynx/application/dtos/localGroup/LocalGroupDataComplete.java
@@ -1,11 +1,22 @@
 package com.pedro.sphynx.application.dtos.localGroup;
 
+import java.util.List;
+
 import com.pedro.sphynx.application.dtos.group.GroupDataComplete;
 import com.pedro.sphynx.application.dtos.local.LocalDataComplete;
+import com.pedro.sphynx.infrastructure.entities.Group;
+import com.pedro.sphynx.infrastructure.entities.Local;
 import com.pedro.sphynx.infrastructure.entities.LocalGroup;
 
-public record LocalGroupDataComplete(Long id, LocalDataComplete local, GroupDataComplete group) {
+public record LocalGroupDataComplete(LocalDataComplete local, List<GroupDataComplete> groups) {
+    //constructor overload to handle different ways to call the record
+    public LocalGroupDataComplete(Local local, Group group){
+        this(new LocalDataComplete(local), List.of(new GroupDataComplete(group)));
+    }
     public LocalGroupDataComplete(LocalGroup data){
-        this(data.getId(), new LocalDataComplete(data.getLocal()), new GroupDataComplete(data.getGroup()));
+        this(new LocalDataComplete(data.getLocal()), List.of(new GroupDataComplete(data.getGroup())));
+    }
+    public LocalGroupDataComplete(Local local, List<Group> groups){
+        this(new LocalDataComplete(local), groups.stream().map(GroupDataComplete::new).toList());
     }
 }

--- a/src/main/java/com/pedro/sphynx/domain/LocalService.java
+++ b/src/main/java/com/pedro/sphynx/domain/LocalService.java
@@ -3,6 +3,7 @@ package com.pedro.sphynx.domain;
 import com.pedro.sphynx.application.dtos.local.LocalDataComplete;
 import com.pedro.sphynx.application.dtos.local.LocalDataEditInput;
 import com.pedro.sphynx.application.dtos.local.LocalDataInput;
+import com.pedro.sphynx.application.dtos.localGroup.LocalGroupDataComplete;
 import com.pedro.sphynx.infrastructure.entities.Group;
 import com.pedro.sphynx.infrastructure.entities.Local;
 import com.pedro.sphynx.infrastructure.entities.LocalGroup;
@@ -10,10 +11,12 @@ import com.pedro.sphynx.infrastructure.exceptions.Validation;
 import com.pedro.sphynx.infrastructure.repository.LocalGroupRepository;
 import com.pedro.sphynx.infrastructure.repository.LocalRepository;
 import com.pedro.sphynx.infrastructure.repository.GroupRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
@@ -73,8 +76,18 @@ public class LocalService {
         return null;
     }
     
-    public List<LocalDataComplete> getAllLocalsWithGroups() {
-        List<Local> locals = repository.findAll();
-        return locals.stream().map(LocalDataComplete::new).collect(Collectors.toList());
+    public List<LocalGroupDataComplete> getAllLocalsWithGroups() {
+        List<LocalGroup> localGroups = localGroupRepository.findAll();
+
+        //mapping Local entity and Group entity based on the localGroups list
+        //will group a local with all its permission_groups without duplicates
+        Map<Local,List<Group>> localsWithGroups = localGroups.stream()
+            .collect(Collectors.groupingBy(
+                LocalGroup::getLocal,
+                Collectors.mapping(LocalGroup::getGroup,Collectors.toList())
+            ));
+        
+                                                    //will convert the Map to and localGroupDataComplete object then to list
+        return localsWithGroups.entrySet().stream().map(entry -> new LocalGroupDataComplete(entry.getKey(), entry.getValue())).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pedro/sphynx/infrastructure/entities/Local.java
+++ b/src/main/java/com/pedro/sphynx/infrastructure/entities/Local.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Table(name = "locals")
 @Entity(name = "Local")
@@ -25,14 +24,6 @@ public class Local {
     private String mac;
     private LocalDateTime dtcreate;
     private LocalDateTime dtupdate;
-
-    @ManyToMany
-    @JoinTable(
-        name = "locals_groups",
-        joinColumns = @JoinColumn(name = "local_id"),
-        inverseJoinColumns = @JoinColumn(name = "group_id")
-    )
-    private List<Group> groups;
 
     public Local(LocalDataInput data){
         this.name = data.name();


### PR DESCRIPTION
Previously, Locals entity where returning a full LocalGroups object by providing a groups list. 
It used the ```@manytomany``` annotation from JPA, which where fetching by the **```LAZY```** type. However it caused an exception with the Hibernator that could not initialize the Groups inside de groups list correctly, causing a crash every time we requested an Access register. Using eager was not an option due to performance concerns.

What changed:
- **fix** - remove groups list from **Locals** and **LocalDataComplete**. It now returns a full Local object. nothing more nothing less.

- **feat** - re-structure the **LocalGroupDataComplete** to returns a LocalGroups object instead of a LocalGroup, which caused in multiples instances of a Local with differente Groups.

- **refactor** - Changed **LocalService**  ```getAllLocalsWithGroups``` to handle the new LocalGroups logic with LocalGroupDataComplete. It queries for all LocalGroup and then Map each unique Local with a list of its respective groups. Updated **LocalController** GET endpoint to adapt to the new system

