### PR TITLE
Sphynx Finder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ WORKDIR /app
 # Copia o JAR gerado da etapa de build
 COPY --from=build /app/target/*.jar app.jar
 
+ENV DOCKER_CONTAINER=true
+
 # Expõe a porta que será usada pelo Spring Boot
 EXPOSE 8080
 

--- a/src/main/java/com/pedro/sphynx/application/controller/FinderController.java
+++ b/src/main/java/com/pedro/sphynx/application/controller/FinderController.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 
-
 @RestController
 @RequestMapping("deviceFinder")
 public class FinderController {
@@ -24,4 +23,12 @@ public class FinderController {
         List<List<String>> devices = multicastService.getDevices();
         return ResponseEntity.ok(devices);
     }
+
+    @GetMapping("scan")
+    public ResponseEntity<List<List<String>>> scanDevices() {
+        multicastService.finderScan();
+        List<List<String>> devices = multicastService.getDevices();
+        return ResponseEntity.ok(devices);
+    }
+    
 }

--- a/src/main/java/com/pedro/sphynx/application/controller/FinderController.java
+++ b/src/main/java/com/pedro/sphynx/application/controller/FinderController.java
@@ -1,0 +1,27 @@
+package com.pedro.sphynx.application.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pedro.sphynx.domain.MulticastService;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+
+@RestController
+@RequestMapping("deviceFinder")
+public class FinderController {
+
+    @Autowired
+    private MulticastService multicastService;
+
+    @GetMapping
+    public ResponseEntity<List<List<String>>> getDevices() {
+        List<List<String>> devices = multicastService.getDevices();
+        return ResponseEntity.ok(devices);
+    }
+}

--- a/src/main/java/com/pedro/sphynx/application/controller/LocalController.java
+++ b/src/main/java/com/pedro/sphynx/application/controller/LocalController.java
@@ -1,12 +1,11 @@
 package com.pedro.sphynx.application.controller;
 
-import com.pedro.sphynx.application.dtos.local.LocalDataComplete;
 import com.pedro.sphynx.application.dtos.local.LocalDataEditInput;
 import com.pedro.sphynx.application.dtos.local.LocalDataInput;
+import com.pedro.sphynx.application.dtos.localGroup.LocalGroupDataComplete;
 import com.pedro.sphynx.application.dtos.message.MessageDTO;
 import com.pedro.sphynx.domain.LocalService;
 import com.pedro.sphynx.domain.MessageService;
-import com.pedro.sphynx.infrastructure.repository.LocalGroupRepository;
 import com.pedro.sphynx.infrastructure.repository.LocalRepository;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,9 +21,6 @@ public class LocalController implements ControllerIN<LocalDataInput, LocalDataEd
 
     @Autowired
     private LocalRepository repository;
-
-    @Autowired
-    private LocalGroupRepository localGroupRepository;
 
     @Autowired
     private LocalService service;
@@ -54,8 +50,8 @@ public class LocalController implements ControllerIN<LocalDataInput, LocalDataEd
 
     @Override
     @GetMapping
-    public ResponseEntity<List<LocalDataComplete>> get(){
-        List<LocalDataComplete> localsList = service.getAllLocalsWithGroups();
+    public ResponseEntity<List<LocalGroupDataComplete>> get(){
+        List<LocalGroupDataComplete> localsList = service.getAllLocalsWithGroups();
         return ResponseEntity.ok(localsList);
     }
 

--- a/src/main/java/com/pedro/sphynx/application/controller/StatusController.java
+++ b/src/main/java/com/pedro/sphynx/application/controller/StatusController.java
@@ -1,0 +1,29 @@
+package com.pedro.sphynx.application.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pedro.sphynx.application.dtos.message.MessageDTO;
+import com.pedro.sphynx.domain.MessageService;
+
+@RestController
+@RequestMapping("online")
+public class StatusController {
+
+    @Autowired
+    private MessageService messageService;
+
+    @GetMapping
+    public ResponseEntity online() {
+        Map<String, String> objeto = new HashMap<>();
+        objeto.put("message", "Testando conectividade");
+        MessageDTO dto = messageService.createMessage(200, objeto, null);
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/pedro/sphynx/application/dtos/local/LocalDataComplete.java
+++ b/src/main/java/com/pedro/sphynx/application/dtos/local/LocalDataComplete.java
@@ -6,8 +6,8 @@ import com.pedro.sphynx.infrastructure.entities.Local;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record LocalDataComplete(Long id, String name, String mac, LocalDateTime dtcreate, LocalDateTime dtupdate, List<Group> groups) {
+public record LocalDataComplete(Long id, String name, String mac, LocalDateTime dtcreate, LocalDateTime dtupdate) {
     public LocalDataComplete(Local data){
-        this(data.getId(), data.getName(), data.getMac(), data.getDtcreate(), data.getDtupdate(), data.getGroups());
+        this(data.getId(), data.getName(), data.getMac(), data.getDtcreate(), data.getDtupdate());
     }
 }

--- a/src/main/java/com/pedro/sphynx/application/dtos/localGroup/LocalGroupDataComplete.java
+++ b/src/main/java/com/pedro/sphynx/application/dtos/localGroup/LocalGroupDataComplete.java
@@ -1,11 +1,22 @@
 package com.pedro.sphynx.application.dtos.localGroup;
 
+import java.util.List;
+
 import com.pedro.sphynx.application.dtos.group.GroupDataComplete;
 import com.pedro.sphynx.application.dtos.local.LocalDataComplete;
+import com.pedro.sphynx.infrastructure.entities.Group;
+import com.pedro.sphynx.infrastructure.entities.Local;
 import com.pedro.sphynx.infrastructure.entities.LocalGroup;
 
-public record LocalGroupDataComplete(Long id, LocalDataComplete local, GroupDataComplete group) {
+public record LocalGroupDataComplete(LocalDataComplete local, List<GroupDataComplete> groups) {
+    //constructor overload to handle different ways to call the record
+    public LocalGroupDataComplete(Local local, Group group){
+        this(new LocalDataComplete(local), List.of(new GroupDataComplete(group)));
+    }
     public LocalGroupDataComplete(LocalGroup data){
-        this(data.getId(), new LocalDataComplete(data.getLocal()), new GroupDataComplete(data.getGroup()));
+        this(new LocalDataComplete(data.getLocal()), List.of(new GroupDataComplete(data.getGroup())));
+    }
+    public LocalGroupDataComplete(Local local, List<Group> groups){
+        this(new LocalDataComplete(local), groups.stream().map(GroupDataComplete::new).toList());
     }
 }

--- a/src/main/java/com/pedro/sphynx/domain/LocalService.java
+++ b/src/main/java/com/pedro/sphynx/domain/LocalService.java
@@ -3,6 +3,7 @@ package com.pedro.sphynx.domain;
 import com.pedro.sphynx.application.dtos.local.LocalDataComplete;
 import com.pedro.sphynx.application.dtos.local.LocalDataEditInput;
 import com.pedro.sphynx.application.dtos.local.LocalDataInput;
+import com.pedro.sphynx.application.dtos.localGroup.LocalGroupDataComplete;
 import com.pedro.sphynx.infrastructure.entities.Group;
 import com.pedro.sphynx.infrastructure.entities.Local;
 import com.pedro.sphynx.infrastructure.entities.LocalGroup;
@@ -10,10 +11,12 @@ import com.pedro.sphynx.infrastructure.exceptions.Validation;
 import com.pedro.sphynx.infrastructure.repository.LocalGroupRepository;
 import com.pedro.sphynx.infrastructure.repository.LocalRepository;
 import com.pedro.sphynx.infrastructure.repository.GroupRepository;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
@@ -73,8 +76,18 @@ public class LocalService {
         return null;
     }
     
-    public List<LocalDataComplete> getAllLocalsWithGroups() {
-        List<Local> locals = repository.findAll();
-        return locals.stream().map(LocalDataComplete::new).collect(Collectors.toList());
+    public List<LocalGroupDataComplete> getAllLocalsWithGroups() {
+        List<LocalGroup> localGroups = localGroupRepository.findAll();
+
+        //mapping Local entity and Group entity based on the localGroups list
+        //will group a local with all its permission_groups without duplicates
+        Map<Local,List<Group>> localsWithGroups = localGroups.stream()
+            .collect(Collectors.groupingBy(
+                LocalGroup::getLocal,
+                Collectors.mapping(LocalGroup::getGroup,Collectors.toList())
+            ));
+        
+                                                    //will convert the Map to and localGroupDataComplete object then to list
+        return localsWithGroups.entrySet().stream().map(entry -> new LocalGroupDataComplete(entry.getKey(), entry.getValue())).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/pedro/sphynx/domain/MulticastService.java
+++ b/src/main/java/com/pedro/sphynx/domain/MulticastService.java
@@ -198,6 +198,8 @@ class DeviceFinder {
 
                 if (device.size() > 1 && !devices.contains(device) && !localsMacs.contains(device.get(1))) {
                     devices.add(device);
+                } else if (localsMacs.contains(device.get(1)) && devices.contains(device)) {
+                    devices.remove(device);
                 }
 
                 System.out.println("Devices found: " + devices);

--- a/src/main/java/com/pedro/sphynx/domain/MulticastService.java
+++ b/src/main/java/com/pedro/sphynx/domain/MulticastService.java
@@ -107,7 +107,7 @@ public class MulticastService {
 
                     System.out.println("Devices found: " + devices);
 
-                    Thread.sleep(5000);
+                    Thread.sleep(180000);
                 }
             } catch (Exception e) {
                 e.printStackTrace();
@@ -169,5 +169,9 @@ public class MulticastService {
             return null;
         }
         
+    }
+
+    public List<List<String>> getDevices() {
+        return devices;
     }
 }

--- a/src/main/java/com/pedro/sphynx/domain/MulticastService.java
+++ b/src/main/java/com/pedro/sphynx/domain/MulticastService.java
@@ -16,7 +16,7 @@ import jakarta.annotation.PostConstruct;
 @Service
 public class MulticastService {
     
-    private static final int PORT = 57127;
+    private static final int PORT = 57128;
     private InetAddress ipAddress;
     
     @PostConstruct

--- a/src/main/java/com/pedro/sphynx/domain/MulticastService.java
+++ b/src/main/java/com/pedro/sphynx/domain/MulticastService.java
@@ -1,0 +1,103 @@
+package com.pedro.sphynx.domain;
+
+import java.net.DatagramPacket;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MulticastSocket;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PostConstruct;
+
+@Service
+public class MulticastService {
+    
+    private static final int PORT = 57127;
+    private InetAddress ipAddress;
+    
+    @PostConstruct
+    public void startListening() {
+        new Thread(() -> {
+            try {
+                MulticastSocket socket = new MulticastSocket(PORT);
+                
+                InetAddress group = InetAddress.getByName("239.255.255.250");
+
+                // uses the same logic from dnsService.java to get the network interface
+                // it should work using 0.0.0.0 as the inetaddress to get all the interfaces, but it doesn't apparently (? need further testing)
+                Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+                while (interfaces.hasMoreElements()) {
+                    NetworkInterface networkInterface = interfaces.nextElement();
+                    
+                    if (networkInterface.isUp() && !networkInterface.isLoopback()) {
+                        Enumeration<InetAddress> Addresses = networkInterface.getInetAddresses();
+                        while (Addresses.hasMoreElements()){
+                            ipAddress = Addresses.nextElement();
+
+                            if (ipAddress instanceof Inet4Address){
+                                break;
+                            }
+                        }
+                        System.out.println("Entrando no grupo de multicast na interface: " + networkInterface.getName());
+                        socket.joinGroup(new InetSocketAddress(group, PORT), networkInterface);
+                    }
+                }
+                // socket.joinGroup(new InetSocketAddress(group, PORT), NetworkInterface.getByInetAddress(InetAddress.getByName("0.0.0.0")));
+
+                byte[] buffer = new byte[1024];
+                DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+
+                System.out.println("Multicast started on " + PORT);
+                
+                while (true) {
+                    socket.receive(packet);
+                    String message = new String(packet.getData(), 0, packet.getLength());
+                    System.out.print("Received: " + message);
+                    System.out.println(" From: " + packet.getAddress() + ":" + packet.getPort());
+
+                    if ("Request Sphynx API Address".equals(message)) {
+                        InetAddress senderAddress = packet.getAddress();
+                        InetAddress localAddress = getSenderNetwork(senderAddress);
+                        if (localAddress != null) {
+                            String ipAddress = localAddress.getHostAddress();
+                            System.out.println("Sending back IP address: " + ipAddress);
+
+                            byte[] responseMessage = ipAddress.getBytes();
+                            DatagramPacket responsePacket = new DatagramPacket(responseMessage, responseMessage.length, packet.getAddress(), packet.getPort());
+                            socket.send(responsePacket);
+                        } else {
+                            System.out.println("network not found for: " + senderAddress);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }).start();
+    }
+
+    // compares the sender address with the local network interfaces to get the correct one
+    // this way the sender can get the correct IP address to connect to the API
+    private InetAddress getSenderNetwork(InetAddress senderAddress) throws SocketException {
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+            while (addresses.hasMoreElements()) {
+                InetAddress address = addresses.nextElement();
+                if (address instanceof Inet4Address) {
+                    byte[] senderBytes = senderAddress.getAddress();
+                    byte[] localBytes = address.getAddress();
+                    if (senderBytes[0] == localBytes[0] && senderBytes[1] == localBytes[1] && senderBytes[2] == localBytes[2]) {
+                        return address;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/pedro/sphynx/domain/dnsService.java
+++ b/src/main/java/com/pedro/sphynx/domain/dnsService.java
@@ -1,5 +1,6 @@
 package com.pedro.sphynx.domain;
 
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.util.Enumeration;
@@ -8,12 +9,15 @@ import javax.jmdns.*;
 
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 
 @Component
+// only build this class when the app is not built by docker, because we use avahi inside the container
+@ConditionalOnProperty(name = "docker.container", havingValue = "false", matchIfMissing = false)
 public class dnsService {
 
     // Getting mdns variables from application.properties
@@ -44,10 +48,9 @@ public class dnsService {
                     Enumeration<InetAddress> Addresses = networkInterface.getInetAddresses();
                     while (Addresses.hasMoreElements()){
                         ipAddress = Addresses.nextElement(); // assign ipAddress with an ip from the list
-                        String ip = ipAddress.toString();
 
-                        // check with regex if the ip is an ipv4 (must be ipv4, ipv6 won't work), then leaves
-                        if (ip.matches("^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")){
+                        // check if the ip is an ipv4 (must be ipv4, ipv6 won't work), then leaves
+                        if (ipAddress instanceof Inet4Address){
                             break;
                         }
                     }

--- a/src/main/java/com/pedro/sphynx/infrastructure/entities/Local.java
+++ b/src/main/java/com/pedro/sphynx/infrastructure/entities/Local.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Table(name = "locals")
 @Entity(name = "Local")
@@ -25,14 +24,6 @@ public class Local {
     private String mac;
     private LocalDateTime dtcreate;
     private LocalDateTime dtupdate;
-
-    @ManyToMany
-    @JoinTable(
-        name = "locals_groups",
-        joinColumns = @JoinColumn(name = "local_id"),
-        inverseJoinColumns = @JoinColumn(name = "group_id")
-    )
-    private List<Group> groups;
 
     public Local(LocalDataInput data){
         this.name = data.name();

--- a/src/main/java/com/pedro/sphynx/infrastructure/security/SecurityConfigurations.java
+++ b/src/main/java/com/pedro/sphynx/infrastructure/security/SecurityConfigurations.java
@@ -32,6 +32,7 @@ public class SecurityConfigurations {
                 req.requestMatchers("/online").permitAll();
                 req.requestMatchers("/login").permitAll();
                 req.requestMatchers("/login/verify").permitAll();
+                req.requestMatchers("/accessRegisters").permitAll();
                 req.requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll();
                 req.anyRequest().authenticated();
             })

--- a/src/main/java/com/pedro/sphynx/infrastructure/security/SecurityConfigurations.java
+++ b/src/main/java/com/pedro/sphynx/infrastructure/security/SecurityConfigurations.java
@@ -29,9 +29,9 @@ public class SecurityConfigurations {
         return http.csrf(csrf -> csrf.disable())
             .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(req -> {
+                req.requestMatchers("/online").permitAll();
                 req.requestMatchers("/login").permitAll();
                 req.requestMatchers("/login/verify").permitAll();
-                req.requestMatchers("/accessRegisters").permitAll();
                 req.requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll();
                 req.anyRequest().authenticated();
             })

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,7 @@ spring.jpa.show-sql=true
 spring.jpa.hibernate.ddl-auto=update
 mdns.service.type=_cliyo-sphynx._tcp.local.
 mdns.service.name=sphynxapi
+docker.container=false
 server.port=57128
 
 server.error.include-stacktrace=never


### PR DESCRIPTION
This pull request add Features from the former sphynx finder API, with some improvements.

- Implements an /online endpoint open to everyone, for the applications to test if the API is working as intended
- Adds a multicast service using UDP packets in the network `239.255.255.250` on port `57128` to facilitate and optimize connection between devices on the network.
- Add API ip finder using the UDP multicast system to help apps and devices that needs to access API find it.
- Add Device Finder system also using UDP multicast system, on port `51727`. It send packets to devices on network and filter the reponses from Sphynx's ESP32.
- Add `deviceFinder` get endpoint to get all non registered devices.
- Add `deviceFinder/scan` get endpoint to scan and get all non registered devices.
- edit some configurations regarding how DNS service is initialized if docker is present, to evade conflicts